### PR TITLE
Fixes to generateData.sh

### DIFF
--- a/data/tpch-datagen/generateData.sh
+++ b/data/tpch-datagen/generateData.sh
@@ -1,3 +1,5 @@
+set -eo pipefail
+
 SCALE=$1
 
 cd data/tpch-datagen
@@ -5,7 +7,7 @@ if [ ! -d "tpch-dbgen" ]
 then
     git clone https://github.com/amirsh/tpch-dbgen.git
     cd tpch-dbgen
-    git apply dbgen-fix.diff
+    git apply ../dbgen-fix.diff
     make
 else
     echo "tpch-dbgen already exists. Skipping git clone & make"

--- a/data/tpch-datagen/generateData.sh
+++ b/data/tpch-datagen/generateData.sh
@@ -15,5 +15,5 @@ else
 fi
 
 ./dbgen -f -s $SCALE
-mkdir ../data
+mkdir -p ../data
 mv *.tbl ../data


### PR DESCRIPTION
Fix path of git-diff file
Add set -eo pipefail
Change mkdir to mkdir -p (so it doesn't fail if directory already exists).