### PR TITLE
[SE-219] Added examples using Helm

### DIFF
--- a/Kubernetes/README.md
+++ b/Kubernetes/README.md
@@ -37,7 +37,6 @@ This can be done in 2 ways.
 Clone this git repository using the command below
 ```
 git clone https://github.com/Bodo-inc/Bodo-examples.git
-
 ```
 
 #### Step 2: Setup Helm and run 
@@ -60,7 +59,6 @@ To run the chart with your values, go to `Kubernetes/helm` folder and edit the v
 ```
 PODNAME=$(kubectl get pods -o=name)
 kubectl logs -f ${PODNAME}
-
 ```
 
 ### Teardown
@@ -123,7 +121,6 @@ mpijobs.kubeflow.org   2022-01-03T21:19:10Z
 ```
 PODNAME=$(kubectl get pods -o=name)
 kubectl logs -f ${PODNAME}
-
 ```
 
 ### Teardown

--- a/Kubernetes/README.md
+++ b/Kubernetes/README.md
@@ -16,12 +16,62 @@ A docker image created from this Dockerfile is also available on DockerHub: [bod
 You can use this as the base image for your own docker image. For testing and validation purposes this image also includes the [pi calculation example](docker/chicago_crimes.py), which is used in this tutorial.
 In case of private registries, follow instructions from [here](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).
 
-**The examples are tested above using Python-3.9 and Bodo-2022.4**
+## !!!WARNING!!!
+
+Any Bodo job you run on Kubernetes Cluster, make sure to provide the correct **CPU and Memory requests** in the helm or in the yaml file. 
+If the correct values are not provided or the cluster won't have the sufficient cpu or memory, the job will be killed and worker pods will respawn again and again.
+
+Make sure to profile or estimate the CPU and Memory requriments in your local machine and provide those values in the configuration files. This will ensure the job will be run successfully.
+
+
+**The examples are tested using Python-3.9 and Bodo-2022.4**
 
 ## Setup
-Bodo can be deployed in any Kubernetes cluster. For the purposes of this example, we will be using a Kubernetes Cluster in EKS:
+Bodo can be deployed in any Kubernetes cluster. For the purposes of this example, we will be using a Kubernetes Cluster in EKS.
+This can be done in 2 ways.
 
-### Step 1: Install MPIJob Custom Resource Definitions(CRD)
+### Using Helm
+
+#### Step 1: Clone Git Repository
+
+Clone this git repository using the command below
+```
+git clone https://github.com/Bodo-inc/Bodo-examples.git
+
+```
+
+#### Step 2: Setup Helm and run 
+
+Check if Helm is installed in your system using `helm version`. If not, check this [guide](https://helm.sh/docs/intro/install/) for setting up Helm in your system.
+
+To run the sample bodo example, Go to the clone repository and run the following command
+```
+helm install <release-name> Kubernetes/helm
+```
+
+This command will install CRD and deploy a MPIJob which run chicago crimes example.
+
+To run the chart with your values, go to `Kubernetes/helm` folder and edit the values.yaml file with your values and run the above command.
+
+#### Step 3: Get the Results
+
+- When the job finishes running, your launcher pod will change its status to completed and any stdout information can be found in the logs of the launcher pod:
+
+```
+PODNAME=$(kubectl get pods -o=name)
+kubectl logs -f ${PODNAME}
+
+```
+
+### Teardown
+
+- If you want to remove the job, run `helm uninstall <release-name>`. 
+- If you want to delete the MPI-Operator crd, run the command `kubectl delete -f Kubernetes/helm/crds/mpi-operator.yaml`
+
+
+### Manual Process
+
+#### Step 1: Install MPIJob Custom Resource Definitions(CRD)
 
 - The most up-to-date installation guide is available at [MPI-Operator Github](https://github.com/kubeflow/mpi-operator). This example was tested using [v0.3.0](https://github.com/kubeflow/mpi-operator/tree/v0.3.0), as shown below:
 
@@ -44,7 +94,7 @@ NAME                   CREATED AT
 mpijobs.kubeflow.org   2022-01-03T21:19:10Z
 ```
 
-### Step 2: Run your Bodo application
+#### Step 2: Run your Bodo application
 
 - Define a kubernetes resource for your Bodo workload, such as the one defined in [`mpijob.yaml`](mpijob.yaml) that runs the [Chicago Crimes example](docker/chicago_crimes.py). You can modify it based on your cluster configuration: 
 
@@ -66,7 +116,7 @@ mpijobs.kubeflow.org   2022-01-03T21:19:10Z
 
 - View the generated pods by this deployment with `kubectl get pods`. You may inspect any logs by looking at the individual pod's logs.
 
-### Step 3: Get the Results
+#### Step 3: Get the Results
 
 - When the job finishes running, your launcher pod will change its status to completed and any stdout information can be found in the logs of the launcher pod:
 
@@ -76,7 +126,7 @@ kubectl logs -f ${PODNAME}
 
 ```
 
-## Teardown
+### Teardown
 
 - When a job has finished running, you can remove it by running `kubectl delete -f mpijob.yaml`. If you want to delete the MPI-Operator crd, please follow the steps on the [MPI-Operator Github repository](https://github.com/kubeflow/mpi-operator).
 

--- a/Kubernetes/README.md
+++ b/Kubernetes/README.md
@@ -18,7 +18,8 @@ In case of private registries, follow instructions from [here](https://kubernete
 
 ## !!!WARNING!!!
 
-Any Bodo job you run on Kubernetes Cluster, make sure to provide the correct **CPU and Memory requests** in the helm or in the yaml file. 
+Please make sure to provide the correct **CPU and Memory requests** in the helm or yaml file for any bodo job.
+
 If the correct values are not provided or the cluster won't have the sufficient cpu or memory, the job will be killed and worker pods will respawn again and again.
 
 Make sure to profile or estimate the CPU and Memory requriments in your local machine and provide those values in the configuration files. This will ensure the job will be run successfully.
@@ -45,7 +46,12 @@ Check if Helm is installed in your system using `helm version`. If not, check th
 
 To run the sample bodo example, Go to the clone repository and run the following command
 ```
-helm install <release-name> Kubernetes/helm
+helm install <release-name> <helm-directory-path>
+```
+For example, you can run the following for chicago crimes example
+
+```
+helm install chicago-crime Kubernetes/helm
 ```
 
 This command will install CRD and deploy a MPIJob which run chicago crimes example.

--- a/Kubernetes/README.md
+++ b/Kubernetes/README.md
@@ -50,7 +50,7 @@ helm install <release-name> <helm-directory-path>
 For example, you can run the following for chicago crimes example
 
 ```
-helm install chicago-crime Kubernetes/helm
+helm install bodo-job-chicago-crime Kubernetes/helm
 ```
 
 This command will install the MPI-Job CRD and deploy a MPIJob which runs the Chicago Crimes Example.

--- a/Kubernetes/helm/.helmignore
+++ b/Kubernetes/helm/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/Kubernetes/helm/Chart.yaml
+++ b/Kubernetes/helm/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: bodo-k8s-chart
+description: A Helm chart for running Bodo in Kubernetes
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/Kubernetes/helm/crds/mpi-operator.yaml
+++ b/Kubernetes/helm/crds/mpi-operator.yaml
@@ -1,0 +1,485 @@
+# --------------------------------------------------
+# - Single configuration deployment YAML for MPI-Operator
+# - Includes:
+#      CRD
+#      Namespace
+#      RBAC
+#      Controller deployment
+# --------------------------------------------------
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app: mpi-operator
+    app.kubernetes.io/component: mpijob
+    app.kubernetes.io/name: mpi-operator
+    kustomize.component: mpi-operator
+  name: mpi-operator
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app: mpi-operator
+    app.kubernetes.io/component: mpijob
+    app.kubernetes.io/name: mpi-operator
+    kustomize.component: mpi-operator
+  name: mpijobs.kubeflow.org
+spec:
+  group: kubeflow.org
+  names:
+    kind: MPIJob
+    plural: mpijobs
+    shortNames:
+    - mj
+    - mpij
+    singular: mpijob
+  scope: Namespaced
+  versions:
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              mpiReplicaSpecs:
+                properties:
+                  Launcher:
+                    properties:
+                      replicas:
+                        maximum: 1
+                        minimum: 1
+                        type: integer
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  Worker:
+                    properties:
+                      replicas:
+                        minimum: 1
+                        type: integer
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
+              slotsPerWorker:
+                minimum: 1
+                type: integer
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              mpiReplicaSpecs:
+                properties:
+                  Launcher:
+                    properties:
+                      replicas:
+                        maximum: 1
+                        minimum: 1
+                        type: integer
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  Worker:
+                    properties:
+                      replicas:
+                        minimum: 1
+                        type: integer
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
+              slotsPerWorker:
+                minimum: 1
+                type: integer
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v2beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              mpiImplementation:
+                enum:
+                - OpenMPI
+                - Intel
+                type: string
+              mpiReplicaSpecs:
+                properties:
+                  Launcher:
+                    properties:
+                      replicas:
+                        maximum: 1
+                        minimum: 1
+                        type: integer
+                      restartPolicy:
+                        enum:
+                        - Never
+                        - OnFailure
+                        type: string
+                      template:
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                  Worker:
+                    properties:
+                      replicas:
+                        minimum: 1
+                        type: integer
+                      restartPolicy:
+                        enum:
+                        - Never
+                        - OnFailure
+                        type: string
+                      template:
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                required:
+                - Launcher
+                type: object
+              runPolicy:
+                properties:
+                  activeDeadlineSeconds:
+                    description: |
+                      Defines the duration in seconds, relative to its start time, that the launcher
+                      Job may be active before the system tries to terminate it. Defaults to infinite.
+                    minimum: 0
+                    type: integer
+                  backoffLimit:
+                    description: Specifies the number of retries before marking the
+                      launcher Job as failed. Defaults to 6.
+                    minimum: 0
+                    type: integer
+                  cleanPodPolicy:
+                    description: Defines which worker Pods must be deleted after the
+                      Job completes
+                    enum:
+                    - None
+                    - Running
+                    - All
+                    type: string
+                  ttlSecondsAfterFinished:
+                    description: |
+                      Defines the TTL to clean up the launcher Job.
+                      Defaults to infinite. Requires kubernetes 1.21+.
+                    minimum: 0
+                    type: integer
+                type: object
+              slotsPerWorker:
+                minimum: 1
+                type: integer
+              sshAuthMountPath:
+                type: string
+            type: object
+          status:
+            properties:
+              completionTime:
+                format: date-time
+                type: string
+              conditions:
+                items:
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    lastUpdateTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      enum:
+                      - Created
+                      - Running
+                      - Restarting
+                      - Succeeded
+                      - Failed
+                      type: string
+                  type: object
+                type: array
+              lastReconcileTime:
+                format: date-time
+                type: string
+              replicaStatuses:
+                properties:
+                  Launcher:
+                    properties:
+                      active:
+                        type: integer
+                      failed:
+                        type: integer
+                      succeeded:
+                        type: integer
+                    type: object
+                  Worker:
+                    properties:
+                      active:
+                        type: integer
+                      failed:
+                        type: integer
+                      succeeded:
+                        type: integer
+                    type: object
+                type: object
+              startTime:
+                format: date-time
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: mpi-operator
+    app.kubernetes.io/component: mpijob
+    app.kubernetes.io/name: mpi-operator
+    kustomize.component: mpi-operator
+  name: mpi-operator
+  namespace: mpi-operator
+---
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.authorization.kubeflow.org/aggregate-to-kubeflow-mpijobs-admin: "true"
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: mpi-operator
+    app.kubernetes.io/component: mpijob
+    app.kubernetes.io/name: mpi-operator
+    kustomize.component: mpi-operator
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-admin: "true"
+  name: kubeflow-mpijobs-admin
+rules: []
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: mpi-operator
+    app.kubernetes.io/component: mpijob
+    app.kubernetes.io/name: mpi-operator
+    kustomize.component: mpi-operator
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-mpijobs-admin: "true"
+  name: kubeflow-mpijobs-edit
+rules:
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - mpijobs
+  - mpijobs/status
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: mpi-operator
+    app.kubernetes.io/component: mpijob
+    app.kubernetes.io/name: mpi-operator
+    kustomize.component: mpi-operator
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-view: "true"
+  name: kubeflow-mpijobs-view
+rules:
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - mpijobs
+  - mpijobs/status
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: mpi-operator
+    app.kubernetes.io/component: mpijob
+    app.kubernetes.io/name: mpi-operator
+    kustomize.component: mpi-operator
+  name: mpi-operator
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  - services
+  verbs:
+  - create
+  - list
+  - watch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - delete
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/exec
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - create
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - create
+  - list
+  - update
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - list
+  - update
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - mpijobs
+  - mpijobs/finalizers
+  - mpijobs/status
+  verbs:
+  - '*'
+- apiGroups:
+  - scheduling.incubator.k8s.io
+  - scheduling.sigs.dev
+  resources:
+  - queues
+  - podgroups
+  verbs:
+  - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: mpi-operator
+    app.kubernetes.io/component: mpijob
+    app.kubernetes.io/name: mpi-operator
+    kustomize.component: mpi-operator
+  name: mpi-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: mpi-operator
+subjects:
+- kind: ServiceAccount
+  name: mpi-operator
+  namespace: mpi-operator
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: mpi-operator
+    app.kubernetes.io/component: mpijob
+    app.kubernetes.io/name: mpi-operator
+    kustomize.component: mpi-operator
+  name: mpi-operator
+  namespace: mpi-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mpi-operator
+      app.kubernetes.io/component: mpijob
+      app.kubernetes.io/name: mpi-operator
+      kustomize.component: mpi-operator
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: mpi-operator
+        app.kubernetes.io/component: mpijob
+        app.kubernetes.io/name: mpi-operator
+        kustomize.component: mpi-operator
+    spec:
+      containers:
+      - args:
+        - -alsologtostderr
+        - --lock-namespace
+        - mpi-operator
+        image: mpioperator/mpi-operator:latest
+        name: mpi-operator
+      serviceAccountName: mpi-operator

--- a/Kubernetes/helm/templates/mpijob.yaml
+++ b/Kubernetes/helm/templates/mpijob.yaml
@@ -1,20 +1,20 @@
 apiVersion: kubeflow.org/v2beta1
 kind: MPIJob
 metadata:
-  name: chicago-crime
+  name: {{ .Values.name }}
 spec:
-  slotsPerWorker: 4
+  slotsPerWorker: {{ .Values.slotsPerWorker }}
   runPolicy:
     cleanPodPolicy: Running
   sshAuthMountPath: /home/mpiuser/.ssh
   mpiImplementation: Intel
   mpiReplicaSpecs:
     Launcher:
-      replicas: 1
+      replicas: {{ .Values.launcher.replicas}}
       template:
         spec:
           containers:
-            - image: bodoaidocker/kube-mpioperator-minimal
+            - image: {{ .Values.image }}
               imagePullPolicy: Always
               name: mpi-launcher
               securityContext:
@@ -24,10 +24,10 @@ spec:
                 - -n
                 - "8"
                 - python
-                - /home/mpiuser/chicago_crimes.py
+                - {{ .Values.launcher.path }}
 
     Worker:
-      replicas: 2
+      replicas: {{ .Values.worker.replicas }}
       template:
         spec:
           # Replaced shared memory with an empty directory
@@ -38,13 +38,13 @@ spec:
             emptyDir:
               medium: Memory
           containers:
-            - image: bodoaidocker/kube-mpioperator-minimal
+            - image: {{ .Values.image }}
               imagePullPolicy: Always
               name: mpi-worker
-              resources:
+              resources:  
                 requests:
-                   memory: 4Gi
-                   cpu: 2
+                   memory: {{ .Values.worker.memory }}
+                   cpu: {{ .Values.worker.cpu }}
 
               securityContext:
                 runAsUser: 1000

--- a/Kubernetes/helm/values.yaml
+++ b/Kubernetes/helm/values.yaml
@@ -1,0 +1,21 @@
+# Default values for bodo-k8s-chart.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+name: chicago-crime-example
+image: bodoaidocker/kube-mpioperator-minimal:latest
+
+slotsPerWorker: 2
+launcher:
+  replicas: 1
+  # The path of the python file to run
+  # To run your own file, copy your python file to /home/mpiuser and change it here.
+  path: /home/mpiuser/chicago_crimes.py
+
+worker:
+  replicas: 2
+  # Make sure to assign proper resources to workers for the bodo to run successfully.
+  # The below configuration works for chicago crimes example
+  cpu: 2
+  memory: 4Gi
+


### PR DESCRIPTION
Instead of manually installing CRDs and yaml files, the users can use helm to run bodo jobs in kubernetes.