### PR TITLE
Fix Pandas precision config call

### DIFF
--- a/01-Basics-of-HPC-with-Python-SQL/01_A_first_Bodo_computation.ipynb
+++ b/01-Basics-of-HPC-with-Python-SQL/01_A_first_Bodo_computation.ipynb
@@ -125,7 +125,7 @@
    "outputs": [],
    "source": [
     "import pandas as pd, numpy as np\n",
-    "pd.set_option('precision', 2)"
+    "pd.set_option('display.precision', 2)"
    ]
   },
   {


### PR DESCRIPTION
Pandas throws an error for `'precision'` config: `OptionError: Pattern matched multiple keys`. This PR fixes it.