### PR TITLE
Update Quickstart Notebook to work on newest version

### DIFF
--- a/quickstart_notebook.ipynb
+++ b/quickstart_notebook.ipynb
@@ -57,10 +57,7 @@
     "pycharm": {
      "name": "#%%\n"
     },
-    "tags": [],
-    "vscode": {
-     "languageId": "python"
-    }
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -100,10 +97,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "tags": [],
-    "vscode": {
-     "languageId": "python"
-    }
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -172,10 +166,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "tags": [],
-    "vscode": {
-     "languageId": "python"
-    }
+    "tags": []
    },
    "outputs": [],
    "source": [

--- a/quickstart_notebook.ipynb
+++ b/quickstart_notebook.ipynb
@@ -57,7 +57,10 @@
     "pycharm": {
      "name": "#%%\n"
     },
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "python"
+    }
    },
    "outputs": [],
    "source": [
@@ -74,7 +77,7 @@
     "def simple_query():\n",
     "    \n",
     "    # reading file directly from S3\n",
-    "    bc = bodosql.BodoSQLContext( {\"nyctaxi\": bodosql.TablePath(s3_file_path, \"parquet\")})\n",
+    "    bc = bodosql.BodoSQLContext( {\"NYCTAXI\": bodosql.TablePath(s3_file_path, \"parquet\")})\n",
     "    \n",
     "    # executing SQL query \n",
     "    df1 = bc.sql(\"SELECT * FROM nyctaxi LIMIT 8\")\n",
@@ -97,7 +100,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "python"
+    }
    },
    "outputs": [],
    "source": [
@@ -106,15 +112,15 @@
     "@bodo.jit\n",
     "def simple_query_2():\n",
     "    # reading file directly from S3\n",
-    "    bc = bodosql.BodoSQLContext({ \"nyctaxi\": bodosql.TablePath(s3_file_path, \"parquet\")})\n",
+    "    bc = bodosql.BodoSQLContext({ \"NYCTAXI\": bodosql.TablePath(s3_file_path, \"parquet\")})\n",
     "   \n",
     "    # executing SQL query \n",
     "    df1 = bc.sql('''\n",
-    "                SELECT DISTINCT passenger_count\n",
-    "                , ROUND (SUM (fare_amount),0) as TotalFares\n",
-    "                , ROUND (AVG (fare_amount),0) as AvgFares\n",
+    "                SELECT DISTINCT \"passenger_count\"\n",
+    "                , ROUND (SUM (\"fare_amount\"),0) as TotalFares\n",
+    "                , ROUND (AVG (\"fare_amount\"),0) as AvgFares\n",
     "                FROM nyctaxi\n",
-    "                GROUP BY passenger_count\n",
+    "                GROUP BY \"passenger_count\"\n",
     "                ''')\n",
     "    return df1\n",
     "\n",
@@ -166,7 +172,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "tags": []
+    "tags": [],
+    "vscode": {
+     "languageId": "python"
+    }
    },
    "outputs": [],
    "source": [
@@ -187,7 +196,7 @@
     "    df[\"tip_fraction\"] = df.tip_amount / df.fare_amount\n",
     "\n",
     "    df[\"pickup_weekday\"] = df.tpep_pickup_datetime.dt.weekday\n",
-    "    df[\"pickup_weekofyear\"] = df.tpep_pickup_datetime.dt.weekofyear\n",
+    "    df[\"pickup_weekofyear\"] = df.tpep_pickup_datetime.dt.isocalendar().week\n",
     "    df[\"pickup_hour\"] = df.tpep_pickup_datetime.dt.hour\n",
     "    df[\"pickup_week_hour\"] = (df.pickup_weekday * 24) + df.pickup_hour\n",
     "    df[\"pickup_minute\"] = df.tpep_pickup_datetime.dt.minute\n",


### PR DESCRIPTION
Update quickstart notebook to run on newest version due to the latest changes:
- Engine capitalizes table and column names (can escape using double quotes)
- Pandas no longer supports `weekofyear`